### PR TITLE
change onejar-maven-plugin groupId.  "org.dstovall" to "com.jolira"

### DIFF
--- a/QSD/pom.xml
+++ b/QSD/pom.xml
@@ -154,7 +154,7 @@
 			</plugin>
 			
 			<plugin>
-				<groupId>org.dstovall</groupId>
+				<groupId>com.jolira</groupId>
 				<artifactId>onejar-maven-plugin</artifactId>
 				<version>1.4.4</version>
 				<executions>
@@ -177,13 +177,6 @@
 
 		</plugins>
 	</build>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>onejar-maven-plugin.googlecode.com</id>
-			<url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
-		</pluginRepository>
-	</pluginRepositories>
 
 
 


### PR DESCRIPTION
I had error commad "mvn package" in sdedit/QSD dir.

Cause is "Failure to find org.dstovall:onejar-maven-plugin:jar:1.4.4 in http://onejar-maven-plugin.googlecode.com/svn/mavenrepo".

I changed onejar-maven-plugin groupId "org.dstovall" to "com.jolira".
