### PR TITLE
Added @RESET@ command to clear the diagram text tab when running in server mode.

### DIFF
--- a/QSD/src/main/java/net/sf/sdedit/server/Receiver.java
+++ b/QSD/src/main/java/net/sf/sdedit/server/Receiver.java
@@ -42,6 +42,9 @@ import net.sf.sdedit.ui.impl.DiagramTextTab;
  */
 public class Receiver implements Runnable
 {
+	private static final String RESET_STRING = "@RESET";
+	private static final String END_CONNECTION = "end";
+	
     private BufferedReader reader;
 
     private int delay = 100;
@@ -82,8 +85,15 @@ public class Receiver implements Runnable
 
         	@Override
             protected void perform() {
-        		tab.append(appendBuffer.toString());
-                appendBuffer.setLength(0);
+        		// If the RESET_STRING is found then clear the diagram
+        		// 
+        		if( appendBuffer.toString().trim().equals(RESET_STRING) ){
+        			tab.clear();
+        		}
+        		else{
+        			tab.append(appendBuffer.toString());
+        		}
+        		appendBuffer.setLength(0);
             }
         };
         waiter.start();
@@ -113,7 +123,7 @@ public class Receiver implements Runnable
                 line = reader.readLine();
                 if (line != null) {
                     line = line.trim();
-                    if (line.toLowerCase().equals("end")) {
+                    if (line.toLowerCase().equals(END_CONNECTION)) {
                         return;
                     }
                     synchronized (waiter) {

--- a/QSD/src/main/java/net/sf/sdedit/ui/impl/DiagramTextTab.java
+++ b/QSD/src/main/java/net/sf/sdedit/ui/impl/DiagramTextTab.java
@@ -441,6 +441,28 @@ public abstract class DiagramTextTab extends DiagramTab implements DocumentListe
 		}
 	}
 
+	@Override
+	/* Clear out the tab, primarily used when being run in server mode and a new sink/source is 
+	 * discovered at runtime and you want to recreate the diagram.
+	 * 
+	 * (non-Javadoc)
+	 * @see net.sf.sdedit.ui.impl.DiagramTab#clear()
+	 */
+	public void clear(){
+		if (isEventDispatchThread()) {
+			textArea.setText("");
+			// happens automatically via DocumentListener
+			// redrawThread.indicateChange();
+		} else {
+			invokeLater(new Runnable() {
+				public void run() {
+					textArea.setText("");
+					// redrawThread.indicateChange();
+				}
+			});
+		}
+	}
+	
 	public void append(final String text) {
 		if (isEventDispatchThread()) {
 			textArea.setText(textArea.getText() + text);


### PR DESCRIPTION
When running sdedit in server mode I'll sometimes dynamically run across a new source or sink of messages. Rather than recreate a new diagram with the new source/sink I would rather re-use the current diagram. I added a command @RESET@ that, when sent over the TCP connection will cause the diagram to be cleared. This allows me to replay the messages with the new source/sink in place.