### PR TITLE
Made Split u/d | L/R Sticky. Added Tab Change Shortcut. Reduced Tab Pane initial size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Quick Sequence Diagram Editor.lnk

--- a/QSD-lib/src/main/java/net/sf/sdedit/util/collection/IndexedList.java
+++ b/QSD-lib/src/main/java/net/sf/sdedit/util/collection/IndexedList.java
@@ -425,7 +425,7 @@ public class IndexedList<T> implements Collection<T>, Serializable {
 	public T previous(T elem) {
 		Entry previous = entryMap.get(elem).previous;
 		if (previous == null) {
-			return null;
+			return (T) last.content;
 		}
 		return (T) previous.content;
 	}
@@ -434,7 +434,7 @@ public class IndexedList<T> implements Collection<T>, Serializable {
 	public T next(T elem) {
 		Entry next = entryMap.get(elem).next;
 		if (next == null) {
-			return null;
+			return (T) first.content;
 		}
 		return (T) next.content;
 	}

--- a/QSD/src/main/java/net/sf/sdedit/config/Configuration.java
+++ b/QSD/src/main/java/net/sf/sdedit/config/Configuration.java
@@ -75,7 +75,7 @@ public interface Configuration extends DataObject {
 	@Adjustable(dflt = 5, min = 1, max = 100, info = "Top margin", category = "Margins")
 	public void setUpperMargin(int upperMargin);
 
-	@Adjustable(editable = false, info = "Vertical split", category = "Misc")
+	@Adjustable(info = "Editor on bottom", category = "Misc")
 	public void setVerticallySplit(boolean verticallySplit);
 
 	@Adjustable(editable = true, info = "Arrow thickness", category = "Line thickness", min = 1)

--- a/QSD/src/main/java/net/sf/sdedit/editor/Actions.java
+++ b/QSD/src/main/java/net/sf/sdedit/editor/Actions.java
@@ -42,6 +42,10 @@ import static net.sf.sdedit.editor.Shortcuts.SPLIT_LEFT_RIGHT;
 import static net.sf.sdedit.editor.Shortcuts.SPLIT_TOP_BOTTOM;
 import static net.sf.sdedit.editor.Shortcuts.UNDO;
 import static net.sf.sdedit.editor.Shortcuts.WIDEN;
+
+import static net.sf.sdedit.editor.Shortcuts.GOTO_NEXT_TAB;
+import static net.sf.sdedit.editor.Shortcuts.GOTO_PREVIOUS_TAB;
+
 import static net.sf.sdedit.editor.Shortcuts.getShortcut;
 import static net.sf.sdedit.ui.components.buttons.ManagedAction.ICON_NAME;
 
@@ -608,7 +612,8 @@ public final class Actions implements Constants {
 		nextAction = new TabAction<Tab>(Tab.class, ui) {
 
 			{
-				putValue(Action.NAME, "Go to next tab");
+				
+				putValue(Action.NAME,getShortcut(GOTO_NEXT_TAB) + "Go to next tab");
 				putValue(ManagedAction.ID, "GO_TO_NEXT_TAB");
 				putValue(ICON_NAME, "next");
 				putValue(Action.SHORT_DESCRIPTION, "Go to next tab");
@@ -623,7 +628,7 @@ public final class Actions implements Constants {
 		previousAction = new TabAction<Tab>(Tab.class, ui) {
 
 			{
-				putValue(Action.NAME, "Go to previous tab");
+				putValue(Action.NAME, getShortcut(GOTO_PREVIOUS_TAB) + "Go to previous tab");
 				putValue(ManagedAction.ID, "GO_TO_PREVIOUS_TAB");
 				putValue(ICON_NAME, "previous");
 				putValue(Action.SHORT_DESCRIPTION, "Go to previous tab");

--- a/QSD/src/main/java/net/sf/sdedit/editor/Actions.java
+++ b/QSD/src/main/java/net/sf/sdedit/editor/Actions.java
@@ -557,10 +557,10 @@ public final class Actions implements Constants {
 
 		splitLeftRightAction = new TabAction<DiagramTextTab>(DiagramTextTab.class, ui) {
 			{
-				putValue(Action.NAME, getShortcut(SPLIT_LEFT_RIGHT) + "Split view left/right");
+				putValue(Action.NAME, getShortcut(SPLIT_LEFT_RIGHT) + "Editor on left");
 				putValue(ManagedAction.ID, "SPLIT_LEFT_RIGHT");
 				putValue(ICON_NAME, "view_left_right");
-				putValue(Action.SHORT_DESCRIPTION, "Split view left/right");
+				putValue(Action.SHORT_DESCRIPTION, "Editor on left");
 			}
 
 			protected void _actionPerformed(DiagramTextTab tab, ActionEvent evt) {
@@ -570,10 +570,10 @@ public final class Actions implements Constants {
 
 		splitTopBottomAction = new TabAction<DiagramTextTab>(DiagramTextTab.class, ui) {
 			{
-				putValue(Action.NAME, getShortcut(SPLIT_TOP_BOTTOM) + "Split view top/bottom");
+				putValue(Action.NAME, getShortcut(SPLIT_TOP_BOTTOM) + "Editor on bottom");
 				putValue(ManagedAction.ID, "SPLIT_TOP_BOTTOM");
 				putValue(ICON_NAME, "view_top_bottom");
-				putValue(Action.SHORT_DESCRIPTION, "Split view top/bottom");
+				putValue(Action.SHORT_DESCRIPTION, "Editor on bottom");
 			}
 
 			protected void _actionPerformed(DiagramTextTab tab, ActionEvent evt) {

--- a/QSD/src/main/java/net/sf/sdedit/editor/Editor.java
+++ b/QSD/src/main/java/net/sf/sdedit/editor/Editor.java
@@ -431,6 +431,9 @@ public final class Editor implements Constants, UserInterfaceListener
 		ui.addAction("&View", actions.widenAction, actions.canConfigureActivator);
 		ui.addAction("&View", actions.narrowAction, actions.canNarrowActivator);
 		ui.addConfigurationAction("&View", wrapAction, actions.textTabActivator);
+		ui.addAction("&View",actions.previousAction, actions.previousActivator);
+		ui.addAction("&View",actions.nextAction, actions.nextActivator);
+
 		ui.addAction("&View", actions.fullScreenAction, actions.supportsFullScreenActivator);
 
 		ui.addAction("&View", actions.splitLeftRightAction, actions.horizontalSplitPossibleActivator);

--- a/QSD/src/main/java/net/sf/sdedit/editor/Shortcuts.java
+++ b/QSD/src/main/java/net/sf/sdedit/editor/Shortcuts.java
@@ -83,8 +83,11 @@ public class Shortcuts {
 	public static final int EXPORT = 22;
 	
 	public static final int ENABLE_THREADS = 23;
+	
+	public static final int GOTO_NEXT_TAB = 24;
+	public static final int GOTO_PREVIOUS_TAB = 25;
 
-	private static final int MAX = 23;
+	private static final int MAX = 25;
 
 	private static final Shortcuts instance;
 
@@ -160,6 +163,9 @@ public class Shortcuts {
 		shortcuts[PRINT] = ctrl("P");
 		shortcuts[REDRAW] = "F5";
 		shortcuts[ENABLE_THREADS] = ctrl("shift M");
+		
+		shortcuts[GOTO_NEXT_TAB] = ctrl("tab");
+		shortcuts[GOTO_PREVIOUS_TAB] = ctrl("shift tab");
 	}
 
 	private void initForMac() {

--- a/QSD/src/main/java/net/sf/sdedit/editor/Shortcuts.java
+++ b/QSD/src/main/java/net/sf/sdedit/editor/Shortcuts.java
@@ -164,8 +164,8 @@ public class Shortcuts {
 		shortcuts[REDRAW] = "F5";
 		shortcuts[ENABLE_THREADS] = ctrl("shift M");
 		
-		shortcuts[GOTO_NEXT_TAB] = ctrl("tab");
-		shortcuts[GOTO_PREVIOUS_TAB] = ctrl("shift tab");
+		shortcuts[GOTO_NEXT_TAB] = ctrl("shift F6");
+		shortcuts[GOTO_PREVIOUS_TAB] = ctrl("F6");
 	}
 
 	private void initForMac() {

--- a/QSD/src/main/java/net/sf/sdedit/ui/impl/DiagramTextTab.java
+++ b/QSD/src/main/java/net/sf/sdedit/ui/impl/DiagramTextTab.java
@@ -274,11 +274,11 @@ public abstract class DiagramTextTab extends DiagramTab implements DocumentListe
 		remove(splitter);
 		switch (layout) {
 
-		case 0:
+		case 0: // Editor on Left
 			splitter = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, textScroller, getZoomPane());
 			splitter.setResizeWeight(0.2);
 			break;
-		case 1:
+		case 1: // Editor on Bottom
 			splitter = new JSplitPane(JSplitPane.VERTICAL_SPLIT, getZoomPane(), textScroller);
 			splitter.setOneTouchExpandable(true);
 			splitter.setResizeWeight(0.8);
@@ -509,6 +509,8 @@ public abstract class DiagramTextTab extends DiagramTab implements DocumentListe
 			changeTimer.stop();
 			changeTimer.setDelay((Integer) evt.getNewValue());
 			changeTimer.start();
+		} else if (evt.getPropertyName().toLowerCase().equals("verticallysplit")) {
+			layout(((Boolean) evt.getNewValue())?1:0);
 		}
 		somethingChanged();
 	}

--- a/QSD/src/main/java/net/sf/sdedit/ui/impl/UserInterfaceImpl.java
+++ b/QSD/src/main/java/net/sf/sdedit/ui/impl/UserInterfaceImpl.java
@@ -250,7 +250,7 @@ public final class UserInterfaceImpl extends JFrame implements Constants, UserIn
 		Container pane = getContentPane();
 		pane.setLayout(new BorderLayout());
 
-		tabContainer = new TabNavigatorContainer(0.2);
+		tabContainer = new TabNavigatorContainer(0.01);
 
 		tabContainer.addCategory("Sequence diagrams", Icons.getIcon("text"));
 


### PR DESCRIPTION
Modified Split up/down and left/right.
- Exposed on Configuration Dialog. Choices reflected in real time based as are other settings.
- Made choice sticky and saved into sdx file.
- Renamed split up/down to "Editor on bottom"
- Renamed split left/right to "Editor on left"

Added Tab switching shortcut.
- Could not get Ctrl-Tab to work. Toolbar kept stealing focus.
- Ctrl-F6 Previous Tab
- Shift-F6 Next Tab
- Made Previous / Next tab wrap around to other end of list.

Reduced side of tab pane
- From 20% to 1%
- I felt the tab pane was entirely to large on modern widescreen displays.
